### PR TITLE
Update nav link to official CCO documentation page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,7 +35,8 @@ nav:
       - Geospatial Tracking: geospatial-tracking.md
       - Information Model: information.md
       # - Stasis: stasis.md
-  - CCO Classes and Relations: https://tinazunner.github.io/cco-webpage/
+    - CCO Classes and Relations: https://commoncoreontology.github.io/cco-webpage/
+    
 
 extra:
   social:


### PR DESCRIPTION
Replaces the “CCO Classes and Relations” navigation link to point to the official CCO site at https://commoncoreontology.github.io/cco-webpage/ instead of my fork.